### PR TITLE
fix an ambiguous constructor definition

### DIFF
--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -28,7 +28,7 @@ type BufferedInputStream{T} <: IO
 end
 
 
-function BufferedInputStream{T}(source::T, buflen::Int=100000)
+function BufferedInputStream{T}(source::T, buflen::Integer=100000)
     return BufferedInputStream{T}(source, Array(UInt8, buflen), 1, 0, 0)
 end
 

--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -27,7 +27,7 @@ type BufferedOutputStream{T} <: IO
 end
 
 
-function BufferedOutputStream{T}(sink::T, buflen::Int=100000)
+function BufferedOutputStream{T}(sink::T, buflen::Integer=100000)
     return BufferedOutputStream{T}(sink, Array(UInt8, buflen), 1)
 end
 


### PR DESCRIPTION
This will suppress a warning message about an ambiguous constructor:

```
INFO: Recompiling stale cache file /Users/kenta/.julia/lib/v0.4/BufferedStreams.ji for module BufferedStreams.
WARNING: New definition
    call(Type{BufferedStreams.BufferedInputStream}, #T<:Any, Int64) at /Users/kenta/.julia/v0.4/BufferedStreams/src/bufferedinputstream.jl:32
is ambiguous with:
    call(Type{BufferedStreams.BufferedInputStream}, Array{UInt8, 1}, Integer) at /Users/kenta/.julia/v0.4/BufferedStreams/src/sources.jl:52.
To fix, define
    call(Type{BufferedStreams.BufferedInputStream}, Array{UInt8, 1}, Int64)
before the new definition.
```

This happens when I wrote the following code:

```julia
using BufferedStreams
BufferedInputStream([0x00, 0x01])
```