### PR TITLE
Return actual num bytes written in write()

### DIFF
--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -84,6 +84,7 @@ function Base.append!(stream::BufferedOutputStream, data::Vector{UInt8},
                       start::Int, stop::Int)
     buffer = stream.buffer
     position = stream.position
+    writelen = stop - start + 1
     buflen = length(buffer)
     while true
         if position > buflen
@@ -103,6 +104,7 @@ function Base.append!(stream::BufferedOutputStream, data::Vector{UInt8},
         end
     end
     stream.position = position
+    return writelen
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,15 @@ facts("BufferedOutputStream") do
 
         @fact takebuf_string(stream) == takebuf_string(iobuf) --> true
     end
+
+    context("write_result") do
+        sink = IOBuffer()
+        stream = BufferedOutputStream(sink, 16)
+        for len in 0:10:100
+            result = write(stream, repeat("x", len))
+            @fact result == len --> true
+        end
+    end
 end
 
 


### PR DESCRIPTION
I noticed that BufferedOutputStream.write() just returns the current buffer position returned by `append!`. I changed `append!` to return the number of bytes appended, so the return value of write() consistently returns the actual number of bytes written.