### PR TITLE
BufferedOutputStream not flushing IOStream sink

### DIFF
--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -107,7 +107,12 @@ end
 
 
 function Base.flush(stream::BufferedOutputStream)
-    flushbuffer!(stream)
+    result = flushbuffer!(stream)
+
+    if typeof(stream.sink) <: IOStream
+        flush(stream.sink)
+    end
+    return result
 end
 
 

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -167,6 +167,13 @@ function Base.readbytes!(source::IOStream, buffer::AbstractArray{UInt8}, from::I
 end
 
 
+function writebytes(source::IOStream, buffer::AbstractArray{UInt8}, n::Int)
+    result = write(source, pointer_to_array(pointer(buffer), (n,)))
+    flush(source)
+    return result
+end
+
+
 # TODO: using ios_write, but look into _os_write_all
 #function Base.write(source::IOStream, buffer::Vector{UInt8}, n::Int)
 

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -167,13 +167,6 @@ function Base.readbytes!(source::IOStream, buffer::AbstractArray{UInt8}, from::I
 end
 
 
-function writebytes(source::IOStream, buffer::AbstractArray{UInt8}, n::Int)
-    result = write(source, pointer_to_array(pointer(buffer), (n,)))
-    flush(source)
-    return result
-end
-
-
 # TODO: using ios_write, but look into _os_write_all
 #function Base.write(source::IOStream, buffer::Vector{UInt8}, n::Int)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,7 +191,9 @@ facts("BufferedOutputStream") do
         write(stream, "world")
         @fact stat(path).size --> 0
         write(stream, "!")
-        @fact stat(path).size --> 10
+        # BufferedOutputStream buffer has run out of space,
+        # but IOStream buffer has not
+        @fact stat(path).size --> 0
         flush(stream)
         @fact stat(path).size --> 11
         write(stream, "...")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,20 @@ facts("BufferedOutputStream") do
 
         @fact takebuf_string(stream) == takebuf_string(iobuf) --> true
     end
-end
 
+    context("iostream") do
+        path, io = mktemp()
+        stream = BufferedOutputStream(open(path, "w"), 10)
+        write(stream, "hello")
+        @fact stat(path).size --> 0
+        write(stream, "world")
+        @fact stat(path).size --> 0
+        write(stream, "!")
+        @fact stat(path).size --> 10
+        flush(stream)
+        @fact stat(path).size --> 11
+        write(stream, "...")
+        @fact stat(path).size --> 11
+    end
+end
 


### PR DESCRIPTION
As reported in JuliaLang/julia#14446, a BufferedOutputStream wrapping an IOStream does not flush the IOStream, even when flush() is called on the BufferedOutputStream. Currently, this example creates an empty file "test.txt" and does not write the output until Julia exits:
```
using BufferedStreams.BufferedOutputStream
ostream = BufferedOutputStream(open("test.txt", "w"))
write(ostream, "write a new line \n")
flush(ostream)
```
I added a new `writebytes` method for IOStreams which calls `flush` on the IOStream. I guess that if there's a use case for a BufferedOutputStream around any other buffered IO object, then a more flexible solution is needed.

OTOH, maybe it doesn't make sense to wrap any buffered IO object in a BufferedOutputStream, so maybe that should be disallowed. In that case, it might be better to raise an exception when creating a BufferedOutputStream with an IOStream, since the current behavior is unexpected.