### PR TITLE
call flush(out) when finalized

### DIFF
--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -31,7 +31,9 @@ function BufferedOutputStream{T}(sink::T, bufsize::Integer=default_buffer_size)
     if bufsize ≤ 0
         throw(ArgumentError("buffer size must be positive"))
     end
-    return BufferedOutputStream{T}(sink, Vector{UInt8}(bufsize), 1)
+    stream = BufferedOutputStream{T}(sink, Vector{UInt8}(bufsize), 1)
+    finalizer(stream, s -> isopen(s) && flush(s))
+    return stream
 end
 
 function Base.show{T}(io::IO, stream::BufferedOutputStream{T})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,7 +285,6 @@ end
     end
 end
 
-
 @testset "BufferedOutputStream" begin
     @testset "write" begin
         data = rand(UInt8, 1000000)
@@ -303,6 +302,13 @@ end
         close(stream1)
         close(stream2)
         @test !isopen(sink)
+
+        sink = IOBuffer()
+        stream = BufferedOutputStream(sink)
+        write(stream, 0x00)
+        write(stream, 0x01)
+        finalize(stream)
+        @test takebuf_array(sink) == [0x00, 0x01]
     end
 
     @testset "arrays" begin


### PR DESCRIPTION
To make sure that data written to a buffer are eventually written to the underlying output.