### PR TITLE
Revert "call flush(out) when finalized (#16)"

### DIFF
--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -31,9 +31,7 @@ function BufferedOutputStream{T}(sink::T, bufsize::Integer=default_buffer_size)
     if bufsize ≤ 0
         throw(ArgumentError("buffer size must be positive"))
     end
-    stream = BufferedOutputStream{T}(sink, Vector{UInt8}(bufsize), 1)
-    finalizer(stream, s -> isopen(s) && flush(s))
-    return stream
+    return BufferedOutputStream{T}(sink, Vector{UInt8}(bufsize), 1)
 end
 
 function Base.show{T}(io::IO, stream::BufferedOutputStream{T})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,6 +292,7 @@ end
     end
 end
 
+
 @testset "BufferedOutputStream" begin
     @testset "write" begin
         data = rand(UInt8, 1000000)
@@ -309,13 +310,6 @@ end
         close(stream1)
         close(stream2)
         @test !isopen(sink)
-
-        sink = IOBuffer()
-        stream = BufferedOutputStream(sink)
-        write(stream, 0x00)
-        write(stream, 0x01)
-        finalize(stream)
-        @test takebuf_array(sink) == [0x00, 0x01]
     end
 
     @testset "arrays" begin


### PR DESCRIPTION
This reverts commit 174c878609fb7ed514b891e30cb1929e6fb4beb5.

I thought it was a good idea, but now I think it was wrong. It is not a way of GNU libc and not documented in the manual of Julia. Even worse, it causes test failure in Bio.jl (https://travis-ci.org/BioJulia/Bio.jl/jobs/135293079).