### PR TITLE
Fix a minor type stability issue

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -14,8 +14,8 @@ end
 # --------
 
 function readbytes!(source::IOStream, buffer::AbstractArray{UInt8}, from::Int, to::Int)
-    return ccall(:ios_readall, UInt, (Ptr{Void}, Ptr{Void}, UInt), source.ios,
-                 pointer(buffer, from), to - from + 1)
+    return Int(ccall(:ios_readall, UInt, (Ptr{Void}, Ptr{Void}, UInt), source.ios,
+                     pointer(buffer, from), to - from + 1))
 end
 
 # TODO: using ios_write, but look into _os_write_all


### PR DESCRIPTION
Since `fillbuffer!` returns either 0 or the return value of `readbytes!`, this `readbytes!` method should return an Int. This is consistent with the behavior of `readbytes!` in Base.