### PR TITLE
No need to  import Compat.String since it is not extended

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using BufferedStreams
 using Compat
-
-import Compat.String
+using Compat.String
 
 if VERSION >= v"0.5-"
     using Base.Test


### PR DESCRIPTION
Minor nitpick issue, but thought I would make the change anyways :)  Thanks again!