### PR TITLE
implement the immobilized buffer

### DIFF
--- a/src/emptystream.jl
+++ b/src/emptystream.jl
@@ -17,7 +17,7 @@ Base.position(stream::BufferedOutputStream{EmptyStream}) = stream.position - 1
 # ---------------------
 
 function BufferedInputStream(data::Vector{UInt8}, len::Integer=endof(data))
-    return BufferedInputStream{EmptyStream}(EmptyStream(), data, 1, len, 0)
+    return BufferedInputStream{EmptyStream}(EmptyStream(), data, 1, len, 0, false)
 end
 
 function fillbuffer!(stream::BufferedInputStream{EmptyStream})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,6 +285,24 @@ end
         end
     end
 
+    @testset "immobilized buffer" begin
+        stream = BufferedInputStream(IOBuffer("abcdefg"), 2)
+        stream.immobilized = false
+        @assert read(stream, UInt8) == UInt8('a')
+        mark(stream)
+        @assert read(stream, UInt8) == UInt8('b')
+        BufferedStreams.fillbuffer!(stream)
+        @test stream.buffer[1] == UInt8('b')
+
+        stream = BufferedInputStream(IOBuffer("abcdefg"), 2)
+        stream.immobilized = true
+        @assert read(stream, UInt8) == UInt8('a')
+        mark(stream)
+        @assert read(stream, UInt8) == UInt8('b')
+        BufferedStreams.fillbuffer!(stream)
+        @test stream.buffer[2] == UInt8('b')
+    end
+
     @testset "misc." begin
         stream = BufferedInputStream(IOBuffer("foobar"), 10)
         @test !BufferedStreams.ensurebuffered!(stream, 10)


### PR DESCRIPTION
This adds an option for `BufferedInputStream` to immobilize buffered data. I'm willing to use this to simplify the implementation of the VCF reader (https://github.com/BioJulia/Bio.jl/pull/378). This shouldn't  be merged yet because I'm not perfectly sure whether this is used in Bio.jl.