### PR TITLE
fix doubleing buffer issue (https://github.com/BioJulia/Libz.jl/issues/52)

### DIFF
--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -63,7 +63,7 @@ function fillbuffer!(stream::BufferedInputStream)
 
     shiftdata!(stream)
     margin = length(stream.buffer) - stream.available
-    if margin * 2 < length(stream.buffer)
+    if margin == 0
         resize!(stream.buffer, length(stream.buffer) * 2)
     end
 


### PR DESCRIPTION
The current buffer resizing strategy is too greedy and requires so much memory when `fillbuffer!` is called repeatedly, which causes https://github.com/BioJulia/Libz.jl/issues/52.