### PR TITLE
Use isdefined instead of imprecise VERSION check for defining unsafe_read

### DIFF
--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -203,7 +203,7 @@ for T in [Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128]
     end
 end
 
-if VERSION > v"0.5-"
+if isdefined(Base, :unsafe_read)
     function Base.unsafe_read(stream::BufferedInputStream, ptr::Ptr{UInt8}, nb::UInt)
         p = ptr
         p_end = ptr + nb

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ function Base.read(stream::InfiniteStream, ::Type{UInt8})
     return stream.byte
 end
 
-if VERSION >= v"0.5-"
+if isdefined(Base, :unsafe_read)
     function Base.unsafe_read(stream::InfiniteStream, pointer::Ptr{UInt8}, n::UInt)
         ccall(:memset, Void, (Ptr{Void}, Cint, Csize_t), pointer, stream.byte, n)
         return nothing
@@ -74,7 +74,7 @@ end
         @test_throws EOFError read(stream, UInt128)
     end
 
-    if VERSION > v"0.5-"
+    if isdefined(Base, :unsafe_read)
         @testset "unsafe_read" begin
             stream = BufferedInputStream(IOBuffer("abcdefg"), 3)
             data = Vector{UInt8}(7)


### PR DESCRIPTION
`v"0.5-"` includes the very first commit after release-0.4 branched