### PR TITLE
Fix Julia 0.7 deprecations.

### DIFF
--- a/src/BufferedStreams.jl
+++ b/src/BufferedStreams.jl
@@ -25,11 +25,14 @@ function _datasize(nbytes)
     k = 1
     for suffix in [" KiB", " MiB", " GiB", " TiB"]
         if nbytes < 1024^(k+1)
-            return string(floor(nbytes / 1024^k, 1), suffix)
+            # Note: The base keyword argument is needed until
+            # https://github.com/JuliaLang/Compat.jl/pull/537 lands or
+            # Compat is dropped.
+            return string(Compat.floor(nbytes / 1024^k, digits = 1, base = 10), suffix)
         end
         k += 1
     end
-    return string(floor(nbytes / 1024^k, 1), " PiB")
+    return string(Compat.floor(nbytes / 1024^k, digits = 1, base = 10), " PiB")
 end
 
 include("bufferedinputstream.jl")

--- a/src/bufferedinputstream.jl
+++ b/src/bufferedinputstream.jl
@@ -36,7 +36,7 @@ function BufferedInputStream(source::T, bufsize::Integer = default_buffer_size) 
     if bufsize ≤ 0
         throw(ArgumentError("buffer size must be positive"))
     end
-    return BufferedInputStream{T}(source, Vector{UInt8}(uninitialized, bufsize), 1, 0, 0, false)
+    return BufferedInputStream{T}(source, Vector{UInt8}(undef, bufsize), 1, 0, 0, false)
 end
 
 function Base.show(io::IO, stream::BufferedInputStream{T}) where T

--- a/src/bufferedoutputstream.jl
+++ b/src/bufferedoutputstream.jl
@@ -31,7 +31,7 @@ function BufferedOutputStream(sink::T, bufsize::Integer=default_buffer_size) whe
     if bufsize ≤ 0
         throw(ArgumentError("buffer size must be positive"))
     end
-    return BufferedOutputStream{T}(sink, Vector{UInt8}(uninitialized, bufsize), 1)
+    return BufferedOutputStream{T}(sink, Vector{UInt8}(undef, bufsize), 1)
 end
 
 function Base.show(io::IO, stream::BufferedOutputStream{T}) where T
@@ -87,7 +87,7 @@ function Base.write(stream::BufferedOutputStream, data::Vector{UInt8})
     checkopen(stream)
     # TODO: find a way to write large vectors directly to the sink bypassing the buffer
     #append!(stream, data, 1, length(data))
-    n_avail = endof(stream.buffer) - stream.position + 1
+    n_avail = lastindex(stream.buffer) - stream.position + 1
     n = min(length(data), n_avail)
     copyto!(stream.buffer, stream.position, data, 1, n)
     stream.position += n
@@ -96,7 +96,7 @@ function Base.write(stream::BufferedOutputStream, data::Vector{UInt8})
         flushbuffer!(stream)
         n_avail = lastindex(stream.buffer) - stream.position + 1
         @assert n_avail > 0
-        n = min(endof(data) - written, n_avail)
+        n = min(lastindex(data) - written, n_avail)
         copyto!(stream.buffer, stream.position, data, written + 1, n)
         stream.position += n
         written += n
@@ -170,5 +170,5 @@ function Base.pointer(stream::BufferedOutputStream, index::Integer = 1)
 end
 
 function available_bytes(stream::BufferedOutputStream)
-    return max(endof(stream.buffer) - stream.position + 1, 0)
+    return max(lastindex(stream.buffer) - stream.position + 1, 0)
 end

--- a/src/emptystream.jl
+++ b/src/emptystream.jl
@@ -53,7 +53,7 @@ end
 # ----------------------
 
 function BufferedOutputStream()
-    return BufferedOutputStream(Vector{UInt8}(uninitialized, 1024))
+    return BufferedOutputStream(Vector{UInt8}(undef, 1024))
 end
 
 function BufferedOutputStream(data::Vector{UInt8})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ end
     if isdefined(Base, :unsafe_read)
         @testset "unsafe_read" begin
             stream = BufferedInputStream(IOBuffer("abcdefg"), 3)
-            data = Vector{UInt8}(uninitialized, 7)
+            data = Vector{UInt8}(undef, 7)
             unsafe_read(stream, pointer(data, 1), 1)
             @test data[1] == UInt8('a')
             unsafe_read(stream, pointer(data, 2), 2)
@@ -115,7 +115,7 @@ end
         data = rand(UInt8, 1000000)
         stream = BufferedInputStream(IOBuffer(data), 1024)
 
-        read_data = Array{UInt8}(uninitialized, 1000)
+        read_data = Array{UInt8}(undef, 1000)
         @test peekbytes!(stream, read_data, 1000) == 1000
         @test data[1:1000] == read_data
         # Check that we read the bytes we just peeked, i.e. that the position
@@ -131,13 +131,13 @@ end
         data = rand(UInt8, 1000000)
         stream = BufferedInputStream(IOBuffer(data), 1024)
 
-        read_data = Array{UInt8}(uninitialized, 2000)
+        read_data = Array{UInt8}(undef, 2000)
         @test peekbytes!(stream, read_data, 2000) == 1024
         # Note that we truncate at buffer size, as
         @test data[1:1024] == read_data[1:1024]
 
         # Check that we only read up to the buffer size
-        read_data = Array{UInt8}(uninitialized, 5)
+        read_data = Array{UInt8}(undef, 5)
         @test peekbytes!(stream, read_data) == 5
         @test data[1:5] == read_data
 
@@ -361,7 +361,7 @@ end
 
         stream = BufferedInputStream(IOBuffer("abcdefg"), 6)
         stream.immobilized = true
-        data = Vector{UInt8}(uninitialized, 7)
+        data = Vector{UInt8}(undef, 7)
         BufferedStreams.readbytes!(stream, data, 1, 3)
         @test data[1:3] == b"abc"
         BufferedStreams.readbytes!(stream, data, 4, 7)
@@ -384,14 +384,14 @@ end
             r"^BufferedInputStream{.*}\(<.* \d+% filled>\)$",
             r"^BufferedStreams.BufferedInputStream{.*}\(<.* \d+% filled>\)$"
         )
-        @test contains(repr(stream), repr_regex)
+        @test occursin(repr_regex, repr(stream))
 
         stream = BufferedInputStream(IOBuffer("foobar"), 4 * 2^10)
-        @test contains(repr(stream), repr_regex)
-        @test contains(repr(stream), r"KiB")
+        @test occursin(repr_regex, repr(stream))
+        @test occursin(r"KiB", repr(stream))
 
         close(stream)
-        @test contains(repr(stream), ifelse(VERSION >= v"0.7-", r"^BufferedInputStream{.*}\(<closed>\)$", r"^BufferedStreams.BufferedInputStream{.*}\(<closed>\)$"))
+        @test occursin(ifelse(VERSION >= v"0.7-", r"^BufferedInputStream{.*}\(<closed>\)$", r"^BufferedStreams.BufferedInputStream{.*}\(<closed>\)$"), repr(stream))
         @test_throws ArgumentError BufferedInputStream(IOBuffer("foo"), 0)
     end
 
@@ -529,9 +529,9 @@ end
         stream = BufferedOutputStream(IOBuffer(), 5)
         @test eof(stream)
         @test pointer(stream) == pointer(stream.buffer)
-        @test contains(string(stream), ifelse(VERSION >= v"0.7-", r"^BufferedOutputStream{.*}\(<.* \d+% filled>\)$", r"^BufferedStreams\.BufferedOutputStream{.*}\(<.* \d+% filled>\)$"))
+        @test occursin(ifelse(VERSION >= v"0.7-", r"^BufferedOutputStream{.*}\(<.* \d+% filled>\)$", r"^BufferedStreams\.BufferedOutputStream{.*}\(<.* \d+% filled>\)$"), string(stream))
         close(stream)
-        @test contains(string(stream), ifelse(VERSION >= v"0.7-", r"^BufferedOutputStream{.*}\(<closed>\)$", r"^BufferedStreams\.BufferedOutputStream{.*}\(<closed>\)$"))
+        @test occursin(ifelse(VERSION >= v"0.7-", r"^BufferedOutputStream{.*}\(<closed>\)$", r"^BufferedStreams\.BufferedOutputStream{.*}\(<closed>\)$"), string(stream))
         @test_throws ArgumentError BufferedOutputStream(IOBuffer(), 0)
     end
 end


### PR DESCRIPTION
# Fix remaining Julia 0.7 deprecations.

* Keyword for `digits` argument of `floor`.
* `uninitialized` → `undef`
* `endof` → `lastindex`
* `contains` → `occursin`
