### PR TITLE
Add Project.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.3
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.3
   - nightly
 notifications:
   email: false
@@ -11,6 +12,8 @@ notifications:
 matrix:
   allow_failures:
   - julia: nightly
+
+script: travis_wait 30 julia --code-coverage -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:
   - julia -e 'using Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); Pkg.add("Coverage")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   allow_failures:
   - julia: nightly
 
-script: travis_wait 30 julia --code-coverage -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+script: travis_wait 60 julia --code-coverage -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:
   - julia -e 'using Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); Pkg.add("Coverage")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - 1.3
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.3
+  - 1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,10 @@
+name = "BufferedStreams"
+uuid = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
+version = "1.0.1"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+
+[compat]
+julia = "0.7, 1"
+Compat = "2, 3"

--- a/Project.toml
+++ b/Project.toml
@@ -6,5 +6,11 @@ version = "1.0.1"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 Compat = "2, 3"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
 julia = "1"
-Compat = "2, 3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 version = "1.0.1"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
 julia = "1"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7
-Compat

--- a/src/BufferedStreams.jl
+++ b/src/BufferedStreams.jl
@@ -26,7 +26,7 @@ function _datasize(nbytes)
         end
         k += 1
     end
-    return string(Compat.floor(nbytes / 1024^k, digits = 1, base = 10), " PiB")
+    return string(floor(nbytes / 1024^k, digits = 1, base = 10), " PiB")
 end
 
 include("bufferedinputstream.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -393,7 +393,11 @@ end
 
         # read byte by byte
         ok = true
-        for i in 1:2^30
+        for i in 1:2^29
+            ok = ok && (read(stream, UInt8) == byte)
+        end
+        @info "half done with massive read!" # avoid travis timeout
+        for i in 1+2^29:2^30
             ok = ok && (read(stream, UInt8) == byte)
         end
         @test ok


### PR DESCRIPTION
This package constrains Compat.jl to version 2, blocking the installation of version 3. I think is assumed from the REQUIRE file, the limit in the registry is here: https://github.com/JuliaRegistries/General/blob/master/B/BufferedStreams/Compat.toml 
See https://github.com/JuliaRegistries/General/pull/8297 for discussion of other packages with similar issues. 

This PR adds the simplest possible Project.toml file, with looser bounds. Perhaps it should also remove the REQUIRE file. 

I can't seem to get tests to run locally, but we'll see what travis thinks?